### PR TITLE
Removed WAT from enabled plugins.

### DIFF
--- a/Godot/project.godot
+++ b/Godot/project.godot
@@ -47,7 +47,7 @@ gdscript/warnings/return_value_discarded=false
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/WAT/plugin.cfg", "res://addons/file_downloader/plugin.cfg" )
+enabled=PoolStringArray( "res://addons/file_downloader/plugin.cfg" )
 
 [global]
 


### PR DESCRIPTION
WAT isn't used yet and is ignored by git which led to crashes when
opening the project after downloading it from github.